### PR TITLE
Add E008 typed relationship validation (Phase 2.5)

### DIFF
--- a/akf.yaml
+++ b/akf.yaml
@@ -41,3 +41,13 @@ enums:
     - active
     - completed
     - archived
+
+# Valid relationship type labels for [[Note|type]] syntax in the related field.
+# Untyped links [[Note]] remain valid regardless of this list.
+relationship_types:
+  - implements
+  - requires
+  - extends
+  - references
+  - supersedes
+  - part-of

--- a/akf/config.py
+++ b/akf/config.py
@@ -31,6 +31,15 @@ import yaml
 # Canonical defaults — mirrored in akf/defaults/akf.yaml
 # These are the single source of truth when no config file is found.
 
+_DEFAULT_RELATIONSHIP_TYPES: list[str] = [
+    "implements",
+    "requires",
+    "extends",
+    "references",
+    "supersedes",
+    "part-of",
+]
+
 _DEFAULT_DOMAINS: list[str] = [
     "ai-system",
     "api-design",
@@ -92,13 +101,17 @@ class AKFConfig:
     Resolved AKF configuration.
 
     Attributes:
-        domains:        Valid values for the `domain` metadata field.
-        enums:          Valid values for `type`, `level`, and `status` fields.
-        schema_version: Version of the akf.yaml schema used.
-        source:         Path to the loaded config file, or None if using defaults.
+        domains:             Valid values for the `domain` metadata field.
+        enums:               Valid values for `type`, `level`, and `status` fields.
+        relationship_types:  Valid typed relationship labels for the `related` field.
+        schema_version:      Version of the akf.yaml schema used.
+        source:              Path to the loaded config file, or None if using defaults.
     """
     domains: list[str] = field(default_factory=lambda: list(_DEFAULT_DOMAINS))
     enums: AKFEnums = field(default_factory=AKFEnums)
+    relationship_types: list[str] = field(
+        default_factory=lambda: list(_DEFAULT_RELATIONSHIP_TYPES)
+    )
     schema_version: str = "1.0.0"
     source: Optional[Path] = None
 
@@ -131,6 +144,7 @@ def _defaults() -> AKFConfig:
             level=list(_DEFAULT_ENUMS["level"]),
             status=list(_DEFAULT_ENUMS["status"]),
         ),
+        relationship_types=list(_DEFAULT_RELATIONSHIP_TYPES),
         schema_version="1.0.0",
         source=None,
     )
@@ -170,9 +184,17 @@ def _parse_yaml(path: Path) -> AKFConfig:
         status=_enum("status"),
     )
 
+    # ── relationship_types ────────────────────────────────────────────────────
+    rel_types_raw = raw.get("relationship_types", None)
+    if isinstance(rel_types_raw, list) and rel_types_raw:
+        relationship_types = [str(r) for r in rel_types_raw]
+    else:
+        relationship_types = list(_DEFAULT_RELATIONSHIP_TYPES)
+
     return AKFConfig(
         domains=domains,
         enums=enums,
+        relationship_types=relationship_types,
         schema_version=schema_version,
         source=path.resolve(),
     )

--- a/akf/defaults/akf.yaml
+++ b/akf/defaults/akf.yaml
@@ -52,3 +52,13 @@ enums:
     - active
     - completed
     - archived
+
+# Valid relationship type labels for [[Note|type]] syntax in the related field.
+# Untyped links [[Note]] remain valid regardless of this list.
+relationship_types:
+  - implements
+  - requires
+  - extends
+  - references
+  - supersedes
+  - part-of

--- a/akf/error_normalizer.py
+++ b/akf/error_normalizer.py
@@ -88,13 +88,14 @@ def normalize_errors(errors: list[ValidationError]) -> RetryPayload:
 
 def _render_instruction(error: ValidationError) -> str:
     renderers = {
-        ErrorCode.INVALID_ENUM:        _render_invalid_enum,
-        ErrorCode.MISSING_FIELD:       _render_missing_field,
-        ErrorCode.INVALID_DATE_FORMAT: _render_invalid_date_format,
-        ErrorCode.TYPE_MISMATCH:       _render_type_mismatch,
-        ErrorCode.SCHEMA_VIOLATION:    _render_schema_violation,
-        ErrorCode.TAXONOMY_VIOLATION:  _render_taxonomy_violation,
-        ErrorCode.DATE_SEQUENCE:        _render_date_sequence,
+        ErrorCode.INVALID_ENUM:              _render_invalid_enum,
+        ErrorCode.MISSING_FIELD:             _render_missing_field,
+        ErrorCode.INVALID_DATE_FORMAT:       _render_invalid_date_format,
+        ErrorCode.TYPE_MISMATCH:             _render_type_mismatch,
+        ErrorCode.SCHEMA_VIOLATION:          _render_schema_violation,
+        ErrorCode.TAXONOMY_VIOLATION:        _render_taxonomy_violation,
+        ErrorCode.DATE_SEQUENCE:             _render_date_sequence,
+        ErrorCode.INVALID_RELATIONSHIP_TYPE: _render_invalid_relationship_type,
     }
     renderer = renderers.get(error.code, _render_generic)
     return renderer(error)
@@ -170,6 +171,16 @@ def _render_date_sequence(e: ValidationError) -> str:
         f"Field `created`/`updated`: the `created` date must not be after `updated`.\n"
         f"   {e.received}\n"
         f"   Set `updated` to a date >= `created`. Do not modify any other fields."
+    )
+
+
+def _render_invalid_relationship_type(e: ValidationError) -> str:
+    valid_str = _format_list(e.expected)
+    return (
+        f"Field `related`: relationship_type must be one of: {valid_str}.\n"
+        f"   You provided: {e.received!r}.\n"
+        f"   Use [[Note|type]] format with a valid type, or [[Note]] without type.\n"
+        f"   Do not modify any other fields."
     )
 
 

--- a/akf/validation_error.py
+++ b/akf/validation_error.py
@@ -16,6 +16,7 @@ class ErrorCode(str, Enum):
     SCHEMA_VIOLATION = "E005_SCHEMA_VIOLATION"
     TAXONOMY_VIOLATION = "E006_TAXONOMY_VIOLATION"
     DATE_SEQUENCE = "E007_DATE_SEQUENCE"  # created > updated semantic violation
+    INVALID_RELATIONSHIP_TYPE = "E008_INVALID_RELATIONSHIP_TYPE"
 
 
 class Severity(str, Enum):
@@ -117,5 +118,18 @@ def date_sequence_violation(created: Any, updated: Any) -> ValidationError:
         field="created/updated",
         expected=f"created ({created}) <= updated ({updated})",
         received=f"created ({created}) > updated ({updated})",
+        severity=Severity.ERROR,
+    )
+
+
+def invalid_relationship_type(
+    link: str, rel_type: str, valid_types: list
+) -> ValidationError:
+    """Construct E008 error for an unrecognized typed relationship."""
+    return ValidationError(
+        code=ErrorCode.INVALID_RELATIONSHIP_TYPE,
+        field="related",
+        expected=valid_types,
+        received=f"[[{link}|{rel_type}]]",
         severity=Severity.ERROR,
     )

--- a/akf/validator.py
+++ b/akf/validator.py
@@ -12,6 +12,7 @@ Enforces:
   - Date format ISO 8601 (E003)
   - created ≤ updated (E007) — CANON-DEFER-002 ✅
   - Tags array min 3 items (E004)
+  - Typed related links [[Note|type]] validated against allowed types (E008)
 
 Changelog:
   - Phase 2.2 (Model C): E006 promoted to error, E001–E006 enforced
@@ -19,6 +20,8 @@ Changelog:
       CANON-DEFER-001: enums + taxonomy loaded from get_config() (akf.yaml)
       CANON-DEFER-002: created ≤ updated semantic constraint (E007)
       CANON-DEFER-003: title isinstance str enforcement (E004)
+  - Phase 2.5 (Model E):
+      Typed relationships: [[Note|type]] syntax with E008_INVALID_RELATIONSHIP_TYPE
 """
 
 import re
@@ -36,6 +39,7 @@ from akf.validation_error import (
     date_sequence_violation,
     invalid_date_format,
     invalid_enum,
+    invalid_relationship_type,
     missing_field,
     taxonomy_violation,
     type_mismatch,
@@ -53,6 +57,10 @@ REQUIRED_FIELDS = [
 DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 TAGS_MIN = 3
+
+# Matches [[Note Name]] (untyped) or [[Note Name|rel-type]] (typed).
+# Group 1: note name; Group 2: relationship type (optional).
+_RELATED_LINK_RE = re.compile(r"^\[\[([^\|\]]+?)(?:\|([^\]]+))?\]\]$")
 
 
 # ---------------------------------------------------------------------------
@@ -92,7 +100,7 @@ def validate(document: str, taxonomy_path: Path | None = None) -> list[Validatio
     errors.extend(_check_taxonomy(metadata, valid_domains))
     errors.extend(_check_dates(metadata))                # includes CANON-DEFER-002
     errors.extend(_check_tags(metadata))
-    errors.extend(_check_related(metadata))              # WARNING: recommended field
+    errors.extend(_check_related(metadata, cfg))         # WARNING + E008 typed links
 
     return errors
 
@@ -255,8 +263,26 @@ def _check_tags(metadata: dict) -> list[ValidationError]:
     return []
 
 
-def _check_related(metadata: dict) -> list[ValidationError]:
-    """W001: related field missing or empty — warning only, never blocks commit."""
+def _check_related(metadata: dict, cfg=None) -> list[ValidationError]:
+    """
+    Validate the related field.
+
+    W001: field missing or empty — warning only, never blocks commit.
+    E008: typed link [[Note|type]] uses an unrecognized relationship type.
+
+    Untyped links [[Note]] are always valid (backward compatible).
+
+    Args:
+        metadata: Parsed frontmatter dict.
+        cfg:      AKFConfig providing relationship_types; loaded via get_config()
+                  if not supplied.
+
+    Returns:
+        List of ValidationError (W001 warnings and/or E008 errors).
+    """
+    if cfg is None:
+        cfg = get_config()
+
     related = metadata.get("related")
     if not related:
         return [ValidationError(
@@ -266,7 +292,22 @@ def _check_related(metadata: dict) -> list[ValidationError]:
             received="absent" if related is None else "empty list",
             severity=Severity.WARNING,
         )]
-    return []
+
+    errors: list[ValidationError] = []
+    valid_types = cfg.relationship_types
+
+    for item in related:
+        if not isinstance(item, str):
+            continue
+        match = _RELATED_LINK_RE.match(item.strip())
+        if match is None:
+            continue  # not a WikiLink — ignore (not our schema to enforce here)
+        note_name = match.group(1)
+        rel_type = match.group(2)
+        if rel_type is not None and rel_type not in valid_types:
+            errors.append(invalid_relationship_type(note_name, rel_type, valid_types))
+
+    return errors
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/corpus/Chain_of_Thought_Reasoning_in_AI_Agents.md
+++ b/tests/fixtures/corpus/Chain_of_Thought_Reasoning_in_AI_Agents.md
@@ -6,9 +6,9 @@ level: advanced
 status: active
 tags: [chain-of-thought, reasoning, ai-agents, prompting, llm]
 related:
-  - "[[Prompt_Engineering_Techniques_for_Structured_Output]]"
+  - "[[Prompt_Engineering_Techniques_for_Structured_Output|supersedes]]"
   - "[[LLM_Context_Window_Management]]"
-  - "[[LLM_Output_Validation_Pipeline_Architecture]]"
+  - "[[LLM_Output_Validation_Pipeline_Architecture|references]]"
 created: 2026-03-10
 updated: 2026-03-10
 ---

--- a/tests/fixtures/corpus/Deterministic_Retry_Logic_in_LLM_Pipelines.md
+++ b/tests/fixtures/corpus/Deterministic_Retry_Logic_in_LLM_Pipelines.md
@@ -7,8 +7,8 @@ status: active
 version: v1.0
 tags: [retry, llm, pipeline, determinism, error-handling]
 related:
-  - "[[LLM_Output_Validation_Pipeline_Architecture]]"
-  - "[[Schema_as_Contract_Pattern]]"
+  - "[[LLM_Output_Validation_Pipeline_Architecture|implements]]"
+  - "[[Schema_as_Contract_Pattern|references]]"
   - "[[AI_Pipeline_Reliability_Audit]]"
 created: 2026-03-10
 updated: 2026-03-10

--- a/tests/fixtures/corpus/LLM_Output_Validation_Pipeline_Architecture.md
+++ b/tests/fixtures/corpus/LLM_Output_Validation_Pipeline_Architecture.md
@@ -7,8 +7,8 @@ status: active
 version: v1.0
 tags: [llm, validation, pipeline, architecture, ai-engineering]
 related:
-  - "[[Schema_as_Contract_Pattern]]"
-  - "[[Deterministic_Retry_Logic]]"
+  - "[[Schema_as_Contract_Pattern|extends]]"
+  - "[[Deterministic_Retry_Logic|requires]]"
   - "[[AI_Pipeline_Reliability_Audit]]"
 created: 2026-03-10
 updated: 2026-03-10

--- a/tests/fixtures/corpus/Ontology_Governance_for_AI_Generated_Knowledge_Bases.md
+++ b/tests/fixtures/corpus/Ontology_Governance_for_AI_Generated_Knowledge_Bases.md
@@ -6,8 +6,8 @@ level: advanced
 status: active
 tags: [ontology, governance, knowledge-base, taxonomy, ai-system]
 related:
-  - "[[Domain_Taxonomy]]"
-  - "[[Knowledge_Management_Architecture]]"
+  - "[[Domain_Taxonomy|part-of]]"
+  - "[[Knowledge_Management_Architecture|extends]]"
   - "[[Schema_as_Contract_Pattern]]"
 created: 2026-03-10
 updated: 2026-03-10

--- a/tests/fixtures/corpus/Prompt_Engineering_Techniques_for_Structured_Output.md
+++ b/tests/fixtures/corpus/Prompt_Engineering_Techniques_for_Structured_Output.md
@@ -7,8 +7,8 @@ status: active
 version: v1.0
 tags: [prompt-engineering, structured-output, llm, ai-system, techniques]
 related:
-  - "[[Schema_as_Contract_Pattern]]"
-  - "[[LLM_Context_Window_Management]]"
+  - "[[Schema_as_Contract_Pattern|requires]]"
+  - "[[LLM_Context_Window_Management|references]]"
   - "[[Chain_of_Thought_Reasoning]]"
 created: 2026-03-10
 updated: 2026-03-10

--- a/tests/fixtures/corpus/Schema_as_Contract_Pattern_for_Structured_AI_Output.md
+++ b/tests/fixtures/corpus/Schema_as_Contract_Pattern_for_Structured_AI_Output.md
@@ -7,8 +7,8 @@ status: active
 version: v1.0
 tags: [schema, contract, structured-output, llm, validation]
 related:
-  - "[[LLM_Output_Validation_Pipeline_Architecture]]"
-  - "[[Prompt_Engineering_Techniques]]"
+  - "[[LLM_Output_Validation_Pipeline_Architecture|implements]]"
+  - "[[Prompt_Engineering_Techniques|requires]]"
   - "[[Deterministic_Retry_Logic]]"
 created: 2026-03-10
 updated: 2026-03-10

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,7 +1,7 @@
 """
-tests/test_validator.py — Phase 2.4 validator tests
+tests/test_validator.py — Phase 2.4/2.5 validator tests
 
-Covers CANON-DEFER-001/002/003 changes only.
+Covers CANON-DEFER-001/002/003 changes and typed relationships (E008).
 Existing Phase 2.2/2.3 tests remain untouched.
 
 Fixtures use reset_config() to isolate config state between tests.
@@ -15,8 +15,9 @@ from pathlib import Path
 import pytest
 
 from akf.config import reset_config, load_config, get_config
+from akf.error_normalizer import normalize_errors
 from akf.validator import validate
-from akf.validation_error import ErrorCode
+from akf.validation_error import ErrorCode, Severity
 
 # ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -40,7 +41,12 @@ def make_doc(**overrides) -> str:
         if isinstance(v, list):
             lines.append(f"{k}:")
             for item in v:
-                lines.append(f"  - {item}")
+                # Always quote strings so YAML doesn't misparse [[WikiLinks]]
+                # as flow sequences.
+                if isinstance(item, str):
+                    lines.append(f'  - "{item}"')
+                else:
+                    lines.append(f"  - {item}")
         else:
             lines.append(f"{k}: {v}")
     lines += ["---", "", "# Body"]
@@ -385,3 +391,175 @@ class TestValidDocumentEndToEnd:
         """)
         errors = validate(doc)
         assert errors == [], f"Unexpected errors: {errors}"
+
+
+# ─── E008: typed relationship validation ─────────────────────────────────────
+
+
+class TestTypedRelationships:
+    """Tests for E008_INVALID_RELATIONSHIP_TYPE (Phase 2.5)."""
+
+    def test_untyped_link_is_valid(self):
+        """[[Note Name]] without type always passes."""
+        doc = make_doc(related=["[[Some Note]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_valid_typed_link_implements(self):
+        doc = make_doc(related=["[[Auth Service|implements]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_valid_typed_link_requires(self):
+        doc = make_doc(related=["[[Base Schema|requires]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_valid_typed_link_extends(self):
+        doc = make_doc(related=["[[Base Pattern|extends]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_valid_typed_link_references(self):
+        doc = make_doc(related=["[[RFC 7231|references]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_valid_typed_link_supersedes(self):
+        doc = make_doc(related=["[[Old Design|supersedes]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_valid_typed_link_part_of(self):
+        doc = make_doc(related=["[[Parent System|part-of]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_invalid_typed_link_emits_e008(self):
+        """[[Note|unknown-type]] → E008."""
+        doc = make_doc(related=["[[Some Note|unknown-type]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert len(rel_errors) == 1
+        assert rel_errors[0].severity == Severity.ERROR
+
+    def test_invalid_typed_link_received_contains_link(self):
+        """E008 received field includes the full [[Note|type]] string."""
+        doc = make_doc(related=["[[My Note|invalid]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert len(rel_errors) == 1
+        assert "[[My Note|invalid]]" == rel_errors[0].received
+
+    def test_invalid_typed_link_expected_contains_valid_types(self):
+        """E008 expected field lists the allowed relationship types."""
+        doc = make_doc(related=["[[X|bogus]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert isinstance(rel_errors[0].expected, list)
+        assert "implements" in rel_errors[0].expected
+
+    def test_mixed_valid_and_invalid_typed_links(self):
+        """One valid typed + one invalid typed → exactly one E008."""
+        doc = make_doc(related=["[[Good Note|implements]]", "[[Bad Note|invented]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert len(rel_errors) == 1
+
+    def test_multiple_invalid_typed_links(self):
+        """Two invalid typed links → two E008 errors."""
+        doc = make_doc(related=["[[A|bad1]]", "[[B|bad2]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert len(rel_errors) == 2
+
+    def test_untyped_and_typed_mixed_all_valid(self):
+        """Untyped + typed valid links → no E008."""
+        doc = make_doc(related=["[[Plain Note]]", "[[Other|requires]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_custom_config_with_custom_relationship_types(self, tmp_path: Path):
+        """Custom relationship_types in config overrides defaults."""
+        cfg_file = tmp_path / "akf.yaml"
+        cfg_file.write_text(
+            "taxonomy:\n  domains:\n    - ai-system\n"
+            "relationship_types:\n  - uses\n  - defines\n",
+            encoding="utf-8",
+        )
+        reset_config()
+        get_config(path=cfg_file)
+
+        doc = make_doc(related=["[[A|uses]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_custom_config_rejects_default_type_not_in_custom_list(self, tmp_path: Path):
+        """Default types like 'implements' rejected if not in custom list."""
+        cfg_file = tmp_path / "akf.yaml"
+        cfg_file.write_text(
+            "taxonomy:\n  domains:\n    - ai-system\n"
+            "relationship_types:\n  - uses\n",
+            encoding="utf-8",
+        )
+        reset_config()
+        get_config(path=cfg_file)
+
+        doc = make_doc(related=["[[A|implements]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert len(rel_errors) == 1
+
+    def test_e008_is_blocking_error(self):
+        """E008 must have ERROR severity — blocks commit."""
+        doc = make_doc(related=["[[A|totally-wrong]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors[0].severity == Severity.ERROR
+
+    def test_e008_field_is_related(self):
+        """E008 reports field='related'."""
+        doc = make_doc(related=["[[A|bad]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors[0].field == "related"
+
+    def test_untyped_link_backward_compat_no_e008(self):
+        """Backward compat: existing [[Note Name]] docs never get E008."""
+        doc = make_doc(related=["[[LLM_Output_Validation_Pipeline_Architecture]]",
+                                 "[[Prompt_Engineering_Techniques]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert rel_errors == []
+
+    def test_e008_normalizer_renders_instruction(self):
+        """E008 errors appear in RetryPayload with correct instruction text."""
+        doc = make_doc(related=["[[A|garbage]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        assert len(rel_errors) == 1
+        payload = normalize_errors(rel_errors)
+        assert payload.has_blocking_errors
+        assert len(payload.instructions) == 1
+        instruction = payload.instructions[0]
+        assert "relationship_type" in instruction
+        assert "implements" in instruction
+
+    def test_e008_normalizer_prompt_text(self):
+        """to_prompt_text() includes the E008 instruction."""
+        doc = make_doc(related=["[[X|not-a-type]]"])
+        errors = validate(doc)
+        rel_errors = [e for e in errors if e.code == ErrorCode.INVALID_RELATIONSHIP_TYPE]
+        payload = normalize_errors(rel_errors)
+        text = payload.to_prompt_text()
+        assert "VALIDATION ERRORS" in text
+        assert "relationship_type" in text


### PR DESCRIPTION
## Summary

Implement E008_INVALID_RELATIONSHIP_TYPE validation for typed relationship links in the `related` field, enabling [[Note|type]] syntax with configurable relationship types.

## Type

- [x] feat — new feature

## Changes

- **akf/validation_error.py**: Added `ErrorCode.INVALID_RELATIONSHIP_TYPE` (E008) and `invalid_relationship_type()` constructor
- **akf/config.py**: Added `relationship_types` field to `AKFConfig` with 6 default types (implements, requires, extends, references, supersedes, part-of); loads from config file or uses defaults
- **akf/validator.py**: 
  - Added regex pattern `_RELATED_LINK_RE` to parse `[[Note|type]]` syntax
  - Enhanced `_check_related()` to validate typed relationship links against configured types
  - Untyped links `[[Note]]` remain valid for backward compatibility
- **akf/error_normalizer.py**: Added `_render_invalid_relationship_type()` renderer for E008 error messages
- **akf.yaml** and **akf/defaults/akf.yaml**: Added `relationship_types` configuration section with default values
- **tests/test_validator.py**: 
  - Added 20 comprehensive tests in `TestTypedRelationships` class covering valid/invalid types, custom configs, error fields, and normalizer output
  - Fixed `make_doc()` helper to properly quote WikiLink strings in YAML to prevent misparse
- **Test fixtures**: Updated 6 corpus documents to use typed relationship syntax with valid types

## Quality Gates

- [x] All tests pass (20 new E008 tests + existing test suite)
- [x] Black format compliant
- [x] Pylint ≥ 9.0
- [x] Mypy clean
- [x] Coverage maintained (new tests provide comprehensive coverage of E008 logic)

## Testing

Added 20 unit tests covering:
- Valid typed links for all 6 default relationship types
- Invalid typed links triggering E008
- Error field validation (received, expected, field, severity)
- Mixed valid/invalid links in single document
- Custom config with overridden relationship types
- Backward compatibility with untyped links
- Error normalization and prompt text rendering

All tests pass; existing test suite unaffected.

## Known Issues / Known Unknowns

None.

## Related

Phase 2.5 feature implementation for typed relationship validation.

https://claude.ai/code/session_017YAy9Hrhq5mabXW2mrvtvT