### PR TITLE
Add type validation for related field and simplify YAML generation

### DIFF
--- a/akf/validator.py
+++ b/akf/validator.py
@@ -293,6 +293,9 @@ def _check_related(metadata: dict, cfg=None) -> list[ValidationError]:
             severity=Severity.WARNING,
         )]
 
+    if not isinstance(related, list):
+        return [type_mismatch("related", list, related)]
+
     errors: list[ValidationError] = []
     valid_types = cfg.relationship_types
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+import yaml
+
 import pytest
 
 from akf.config import reset_config, load_config, get_config
@@ -36,21 +38,8 @@ def make_doc(**overrides) -> str:
     }
     fields.update(overrides)
 
-    lines = ["---"]
-    for k, v in fields.items():
-        if isinstance(v, list):
-            lines.append(f"{k}:")
-            for item in v:
-                # Always quote strings so YAML doesn't misparse [[WikiLinks]]
-                # as flow sequences.
-                if isinstance(item, str):
-                    lines.append(f'  - "{item}"')
-                else:
-                    lines.append(f"  - {item}")
-        else:
-            lines.append(f"{k}: {v}")
-    lines += ["---", "", "# Body"]
-    return "\n".join(lines)
+    frontmatter = yaml.safe_dump(fields, default_flow_style=False, allow_unicode=True)
+    return f"---\n{frontmatter}---\n\n# Body"
 
 
 @pytest.fixture(autouse=True)
@@ -563,3 +552,28 @@ class TestTypedRelationships:
         text = payload.to_prompt_text()
         assert "VALIDATION ERRORS" in text
         assert "relationship_type" in text
+
+    def test_related_non_list_emits_type_mismatch(self):
+        """related: 'a string' (not a list) → E004_TYPE_MISMATCH immediately."""
+        doc = textwrap.dedent("""\
+            ---
+            title: Test Document
+            type: concept
+            domain: ai-system
+            level: beginner
+            status: active
+            tags:
+              - a
+              - b
+              - c
+            related: "[[Some Note]]"
+            created: "2026-01-01"
+            updated: "2026-01-02"
+            ---
+
+            # Body
+        """)
+        errors = validate(doc)
+        related_errors = [e for e in errors if e.field == "related"]
+        assert len(related_errors) == 1
+        assert related_errors[0].code == ErrorCode.TYPE_MISMATCH


### PR DESCRIPTION
## Summary

Add early type validation for the `related` field to immediately catch non-list values, and refactor YAML frontmatter generation to use PyYAML instead of manual string building.

## Type

- [x] fix — bug fix
- [x] refactor — no behaviour change

## Changes

- **validator.py**: Added type check in `_check_related()` to return `TYPE_MISMATCH` error immediately if `related` field is not a list, preventing downstream errors
- **test_validator.py**: 
  - Replaced manual YAML frontmatter generation with `yaml.safe_dump()` for cleaner, more maintainable code
  - Added `test_related_non_list_emits_type_mismatch()` test to verify that non-list `related` values are caught with the correct error code

## Quality Gates

- [x] All tests pass
- [x] New test added for the validation fix
- [x] Refactored code is simpler and more maintainable

## Testing

Added unit test `test_related_non_list_emits_type_mismatch()` that verifies a string value for the `related` field immediately produces an `E004_TYPE_MISMATCH` error. The test uses a complete valid document with `related: "[[Some Note]]"` (string instead of list) and confirms exactly one error is returned with the correct error code.

## Known Issues / Known Unknowns

None.

## Related

N/A

https://claude.ai/code/session_01HMEqCf5kB9eM6a1eAorTDC