### PR TITLE
Document E008 validation error and relationship_types config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -150,7 +150,7 @@ GET  /docs
 ```python
 @dataclass
 class ValidationError:
-    code: str        # E001–E007
+    code: str        # E001–E008
     field: str       # YAML field name
     expected: Any    # allowed values or type
     received: Any    # what was found
@@ -168,6 +168,7 @@ class ValidationError:
 | E005 | frontmatter | General schema violation |
 | E006 | domain | Not in configured taxonomy |
 | E007 | created / updated | `created > updated` |
+| E008 | related | Typed relationship label not in `relationship_types` |
 
 **Breaking changes (require MAJOR):** removing an E-code, renaming fields in `ValidationError`, changing severity of an existing code (e.g. warning → error for existing users).
 
@@ -191,6 +192,14 @@ enums:
   type: [concept, guide, ...]   # file type enum
   level: [beginner, ...]        # level enum
   status: [draft, active, ...]  # status enum
+
+relationship_types:             # valid labels for [[Note|type]] syntax
+  - implements
+  - requires
+  - extends
+  - references
+  - supersedes
+  - part-of
 ```
 
 `schema_version: "1.0.0"` — frozen at this value until a breaking change to the config schema occurs, at which point it increments to `"2.0.0"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to AKF are documented here.
 ## [Unreleased]
 
+### Documentation
+
+- Update ARCHITECTURE.md and README to document E008 typed relationship validation and `relationship_types` config key
+
+
 ## [1.0.0] — 2026-03-10
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Validation failures produce typed error codes, not free-form messages:
 | E005 | frontmatter | General schema violation |
 | E006 | domain | Value not in taxonomy |
 | E007 | created / updated | `created` is later than `updated` |
+| E008 | related | Typed relationship label not in `relationship_types` |
 
 The Error Normalizer translates these codes into deterministic correction instructions for the retry:
 


### PR DESCRIPTION
## Summary

Add documentation for E008 validation error code and the new `relationship_types` configuration key that validates typed relationship labels in the `[[Note|type]]` syntax.

## Type

- [x] docs — documentation only

## Changes

- Updated ARCHITECTURE.md to document E008 error code for invalid typed relationship labels
- Added `relationship_types` configuration section to ARCHITECTURE.md with example valid labels (implements, requires, extends, references, supersedes, part-of)
- Updated README.md error code table to include E008
- Updated CHANGELOG.md to document these documentation changes

## Quality Gates

- [x] Documentation only — no code changes requiring tests
- [x] No behavior changes

## Testing

N/A — documentation only

## Known Issues / Known Unknowns

None

## Related

Updates documentation to reflect E008 validation and `relationship_types` config key

https://claude.ai/code/session_01RFyL2b9C8iocP4hw2xFfX9