### PR TITLE
CI hotfix: make Codecov upload non-blocking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
       run: |
         pytest --cov=akf --cov-report=term-missing --cov-report=xml --cov-fail-under=75 -v
     - name: Upload coverage to Codecov
+      continue-on-error: true
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml


### PR DESCRIPTION
## Summary
- mark Codecov upload step as continue-on-error in tests workflow

## Why
The recent main failure in Tests was caused by a transient network error in codecov-action, while pytest itself had already passed.

## Impact
Coverage upload remains attempted, but external Codecov connectivity issues no longer fail the entire test job.